### PR TITLE
Fix logger references

### DIFF
--- a/watchers/ingress_watcher.rb
+++ b/watchers/ingress_watcher.rb
@@ -13,7 +13,7 @@ class IngressWatcher
         begin
           new_notice(notice)
         rescue => ex
-          logger.error(watcher: 'Ingress', status: 'end_watch', error: ex)
+          @logger.error(watcher: 'Ingress', status: 'end_watch', error: ex)
         end
       end
       @logger.info(watcher: 'Ingress', status: 'end_all_watch')

--- a/watchers/service_watcher.rb
+++ b/watchers/service_watcher.rb
@@ -12,7 +12,7 @@ class ServiceWatcher
         begin
           new_notice(notice)
         rescue => ex
-          logger.error(watcher: 'Service', status: 'end_watch', error: ex)
+          @logger.error(watcher: 'Service', status: 'end_watch', error: ex)
         end
       end
       @logger.info(watcher: 'Service', status: 'end_all_watch')


### PR DESCRIPTION
I broke this in https://github.com/fairfaxmedia/area53/commit/d26bdfaec42e3567c9af7833a32cbad553b063ba but having retested it by removing IAM access it is definitely coming through now:

```
[2017-02-22T13:08:07.321600 #1] ERROR -- : {:watcher=>"Service", :status=>"end_watch", :error=>#<Aws::Route53::Errors::AccessDenied: User: arn:aws:sts::OBFUSCATED:assumed-role/OBFUSCATED is not authorized to perform: route53:GetHostedZone on resource: arn:aws:route53:::hostedzone/OBFUSCATED>}
```